### PR TITLE
docs: add SECURITY.md policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+## Supported Versions
+
+We take security seriously. All versions of the Redgifs Downloader extension are currently being supported with security updates and patches. 
+
+| Version | Supported          |
+| ------- | ------------------ |
+| All     | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability within the Redgifs Downloader extension, please **DO NOT** create a public issue. Instead, we ask that you report it privately to ensure the safety of all users while a fix is being developed.
+
+**How to report:**
+1. Use the [GitHub Security Advisories](https://github.com/freerebirth/Redgifs-download-button/security/advisories) feature on this repository to privately report a vulnerability.
+2. Provide a detailed description of the vulnerability and the exact steps to reproduce it.
+3. State the browser (Chrome or Firefox) and version where the issue occurs.
+
+You should receive a response acknowledging the receipt of the vulnerability report within 48 hours. If the vulnerability is confirmed, a patch will be prepared and released as soon as possible.


### PR DESCRIPTION
## Why

Adds a github-recommended \SECURITY.md\ policy to standardise how security vulnerabilities are reported to the maintainers as opposed to creating a public issue. Marks all versions as supported for patches.