### PR TITLE
feat: download location UI in popup (folder / no-folder toggle)

### DIFF
--- a/chrome/background.js
+++ b/chrome/background.js
@@ -49,8 +49,8 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 // ============================================
 function handleDirectDownload(url, filename, sendResponse) {
     chrome.storage.local.get(['downloadFolder'], (result) => {
-        const folder = result.downloadFolder || DEFAULT_DOWNLOAD_FOLDER;
-        const finalFilename = folder + filename;
+        const folder = result.downloadFolder ?? DEFAULT_DOWNLOAD_FOLDER;
+        const finalFilename = folder ? folder + filename : filename;
 
         chrome.downloads.download({
             url,
@@ -321,8 +321,8 @@ async function handleFetchAndDownload(url, filename, sendResponse) {
         const blobUrl = URL.createObjectURL(blob);
 
         chrome.storage.local.get(['downloadFolder'], (result) => {
-            const folder = result.downloadFolder || DEFAULT_DOWNLOAD_FOLDER;
-            const finalFilename = folder + filename;
+            const folder = result.downloadFolder ?? DEFAULT_DOWNLOAD_FOLDER;
+            const finalFilename = folder ? folder + filename : filename;
 
             chrome.downloads.download({
                 url: blobUrl,

--- a/chrome/popup.html
+++ b/chrome/popup.html
@@ -144,12 +144,148 @@
             background: rgba(246, 201, 21, 0.15);
             border-color: rgba(246, 201, 21, 0.35);
         }
+
+        .settings-section {
+            margin-top: 12px;
+            padding: 12px 16px;
+            background: rgba(255, 255, 255, 0.04);
+            border: 1px solid rgba(255, 255, 255, 0.06);
+            border-radius: 8px;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .toggle-label {
+            font-size: 13px;
+            color: rgba(255, 255, 255, 0.8);
+            font-weight: 500;
+        }
+
+        .toggle-switch {
+            position: relative;
+            display: inline-block;
+            width: 36px;
+            height: 20px;
+        }
+
+        .toggle-switch input {
+            opacity: 0;
+            width: 0;
+            height: 0;
+        }
+
+        .toggle-slider {
+            position: absolute;
+            cursor: pointer;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background-color: rgba(255, 255, 255, 0.2);
+            transition: .3s;
+            border-radius: 20px;
+        }
+
+        .toggle-slider:before {
+            position: absolute;
+            content: "";
+            height: 14px;
+            width: 14px;
+            left: 3px;
+            bottom: 3px;
+            background-color: white;
+            transition: .3s;
+            border-radius: 50%;
+        }
+
+        input:checked + .toggle-slider {
+            background-color: #ff5252;
+        }
+
+        input:checked + .toggle-slider:before {
+            transform: translateX(16px);
+        }
+
+        /* Download Location Section */
+        .folder-section {
+            margin-top: 12px;
+            padding: 12px 16px;
+            background: rgba(255, 255, 255, 0.04);
+            border: 1px solid rgba(255, 255, 255, 0.06);
+            border-radius: 8px;
+        }
+
+        .folder-section-label {
+            font-size: 13px;
+            color: rgba(255, 255, 255, 0.8);
+            font-weight: 500;
+            margin-bottom: 10px;
+            display: block;
+        }
+
+        .radio-group {
+            display: flex;
+            flex-direction: column;
+            gap: 7px;
+        }
+
+        .radio-option {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            cursor: pointer;
+            font-size: 13px;
+            color: rgba(255, 255, 255, 0.7);
+        }
+
+        .radio-option input[type="radio"] {
+            accent-color: #ff5252;
+            width: 14px;
+            height: 14px;
+            cursor: pointer;
+            flex-shrink: 0;
+        }
+
+        .folder-input-row {
+            margin-top: 9px;
+            display: none;
+            align-items: center;
+            gap: 6px;
+        }
+
+        .folder-input-row.visible {
+            display: flex;
+        }
+
+        .folder-input {
+            flex: 1;
+            background: rgba(255, 255, 255, 0.07);
+            border: 1px solid rgba(255, 255, 255, 0.14);
+            border-radius: 6px;
+            padding: 5px 9px;
+            font-size: 12px;
+            color: #e0e0e0;
+            outline: none;
+            transition: border-color 0.2s;
+        }
+
+        .folder-input:focus {
+            border-color: rgba(255, 82, 82, 0.5);
+        }
+
+        .folder-hint {
+            font-size: 11px;
+            color: rgba(255, 255, 255, 0.3);
+            margin-top: 5px;
+            min-height: 16px;
+        }
     </style>
 </head>
 <body>
     <div class="header">
         <h2>⬇️ Redgifs Downloader</h2>
-        <div class="version">v1.4</div>
+        <div class="version">v1.5</div>
     </div>
     <div class="info">
         Click the download button on any<br>Redgifs video to save it in HD.
@@ -165,5 +301,30 @@
             <a class="liberapay" href="https://liberapay.com/freerebirth" target="_blank">🎁 Liberapay</a>
         </div>
     </div>
+    <div class="settings-section">
+        <span class="toggle-label">Auto-skip Feed Ads</span>
+        <label class="toggle-switch">
+            <input type="checkbox" id="auto-skip-toggle">
+            <span class="toggle-slider"></span>
+        </label>
+    </div>
+    <div class="folder-section">
+        <span class="folder-section-label">📁 Download Location</span>
+        <div class="radio-group">
+            <label class="radio-option">
+                <input type="radio" name="folder-mode" id="folder-mode-none" value="none">
+                Downloads folder
+            </label>
+            <label class="radio-option">
+                <input type="radio" name="folder-mode" id="folder-mode-sub" value="sub">
+                Subfolder
+            </label>
+        </div>
+        <div class="folder-input-row" id="folder-input-row">
+            <input type="text" class="folder-input" id="folder-name-input" placeholder="Redgifs" maxlength="64">
+        </div>
+        <div class="folder-hint" id="folder-hint"></div>
+    </div>
+    <script src="popup.js"></script>
 </body>
 </html>

--- a/chrome/popup.js
+++ b/chrome/popup.js
@@ -1,0 +1,85 @@
+document.addEventListener('DOMContentLoaded', () => {
+    // ── Ad-skip toggle ──────────────────────────────────────────────
+    const skipToggle = document.getElementById('auto-skip-toggle');
+
+    chrome.storage.local.get(['autoSkipAds'], (result) => {
+        skipToggle.checked = result.autoSkipAds || false;
+    });
+
+    skipToggle.addEventListener('change', (e) => {
+        chrome.storage.local.set({ autoSkipAds: e.target.checked });
+    });
+
+    // ── Download Location ───────────────────────────────────────────
+    const radioNone    = document.getElementById('folder-mode-none');
+    const radioSub     = document.getElementById('folder-mode-sub');
+    const inputRow     = document.getElementById('folder-input-row');
+    const folderInput  = document.getElementById('folder-name-input');
+    const folderHint   = document.getElementById('folder-hint');
+
+    function updateHint(folderName) {
+        if (radioSub.checked && folderName) {
+            folderHint.textContent = 'Saves to: Downloads/' + folderName.trim().replace(/\/+$/, '') + '/';
+        } else if (radioNone.checked) {
+            folderHint.textContent = 'Saves directly to: Downloads/';
+        } else {
+            folderHint.textContent = '';
+        }
+    }
+
+    function applySubfolderMode(folderName) {
+        inputRow.classList.add('visible');
+        folderInput.value = folderName;
+        updateHint(folderName);
+    }
+
+    function applyNoFolderMode() {
+        inputRow.classList.remove('visible');
+        updateHint('');
+    }
+
+    // Load saved state
+    chrome.storage.local.get(['downloadFolder'], (result) => {
+        // null/undefined = first install → default to subfolder "Redgifs"
+        // "" = user explicitly chose no subfolder
+        if (result.downloadFolder === '') {
+            radioNone.checked = true;
+            applyNoFolderMode();
+        } else {
+            const name = (result.downloadFolder || 'Redgifs/').replace(/\/$/, '');
+            radioSub.checked = true;
+            applySubfolderMode(name);
+        }
+    });
+
+    // Radio: Downloads folder
+    radioNone.addEventListener('change', () => {
+        if (radioNone.checked) {
+            applyNoFolderMode();
+            chrome.storage.local.set({ downloadFolder: '' });
+        }
+    });
+
+    // Radio: Subfolder
+    radioSub.addEventListener('change', () => {
+        if (radioSub.checked) {
+            const name = folderInput.value.trim() || 'Redgifs';
+            folderInput.value = name;
+            applySubfolderMode(name);
+            chrome.storage.local.set({ downloadFolder: name + '/' });
+        }
+    });
+
+    // Debounced folder name input
+    let debounceTimer = null;
+    folderInput.addEventListener('input', () => {
+        updateHint(folderInput.value);
+        clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(() => {
+            const name = folderInput.value.trim();
+            if (name) {
+                chrome.storage.local.set({ downloadFolder: name + '/' });
+            }
+        }, 600);
+    });
+});

--- a/firefox/background.js
+++ b/firefox/background.js
@@ -38,8 +38,8 @@ browser.runtime.onMessage.addListener((message, sender) => {
 // ============================================
 async function handleDirectDownload(url, filename) {
     const result = await browser.storage.local.get('downloadFolder');
-    const folder = result.downloadFolder || DEFAULT_DOWNLOAD_FOLDER;
-    const finalFilename = folder + filename;
+    const folder = result.downloadFolder ?? DEFAULT_DOWNLOAD_FOLDER;
+    const finalFilename = folder ? folder + filename : filename;
 
     try {
         const downloadId = await browser.downloads.download({
@@ -162,11 +162,12 @@ async function handleVideoProcessing(videoId, manifest, tabId) {
         const url = URL.createObjectURL(blob);
 
         const storageResult = await browser.storage.local.get('downloadFolder');
-        const folder = storageResult.downloadFolder || DEFAULT_DOWNLOAD_FOLDER;
+        const folder = storageResult.downloadFolder ?? DEFAULT_DOWNLOAD_FOLDER;
+        const dlFilename = folder ? `${folder}redgifs_${videoId}.mp4` : `redgifs_${videoId}.mp4`;
 
         await browser.downloads.download({
             url,
-            filename: `${folder}redgifs_${videoId}.mp4`,
+            filename: dlFilename,
             saveAs: false
         });
     } catch (error) {

--- a/firefox/popup.html
+++ b/firefox/popup.html
@@ -144,12 +144,148 @@
             background: rgba(246, 201, 21, 0.15);
             border-color: rgba(246, 201, 21, 0.35);
         }
+
+        .settings-section {
+            margin-top: 12px;
+            padding: 12px 16px;
+            background: rgba(255, 255, 255, 0.04);
+            border: 1px solid rgba(255, 255, 255, 0.06);
+            border-radius: 8px;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .toggle-label {
+            font-size: 13px;
+            color: rgba(255, 255, 255, 0.8);
+            font-weight: 500;
+        }
+
+        .toggle-switch {
+            position: relative;
+            display: inline-block;
+            width: 36px;
+            height: 20px;
+        }
+
+        .toggle-switch input {
+            opacity: 0;
+            width: 0;
+            height: 0;
+        }
+
+        .toggle-slider {
+            position: absolute;
+            cursor: pointer;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background-color: rgba(255, 255, 255, 0.2);
+            transition: .3s;
+            border-radius: 20px;
+        }
+
+        .toggle-slider:before {
+            position: absolute;
+            content: "";
+            height: 14px;
+            width: 14px;
+            left: 3px;
+            bottom: 3px;
+            background-color: white;
+            transition: .3s;
+            border-radius: 50%;
+        }
+
+        input:checked + .toggle-slider {
+            background-color: #ff5252;
+        }
+
+        input:checked + .toggle-slider:before {
+            transform: translateX(16px);
+        }
+
+        /* Download Location Section */
+        .folder-section {
+            margin-top: 12px;
+            padding: 12px 16px;
+            background: rgba(255, 255, 255, 0.04);
+            border: 1px solid rgba(255, 255, 255, 0.06);
+            border-radius: 8px;
+        }
+
+        .folder-section-label {
+            font-size: 13px;
+            color: rgba(255, 255, 255, 0.8);
+            font-weight: 500;
+            margin-bottom: 10px;
+            display: block;
+        }
+
+        .radio-group {
+            display: flex;
+            flex-direction: column;
+            gap: 7px;
+        }
+
+        .radio-option {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            cursor: pointer;
+            font-size: 13px;
+            color: rgba(255, 255, 255, 0.7);
+        }
+
+        .radio-option input[type="radio"] {
+            accent-color: #ff5252;
+            width: 14px;
+            height: 14px;
+            cursor: pointer;
+            flex-shrink: 0;
+        }
+
+        .folder-input-row {
+            margin-top: 9px;
+            display: none;
+            align-items: center;
+            gap: 6px;
+        }
+
+        .folder-input-row.visible {
+            display: flex;
+        }
+
+        .folder-input {
+            flex: 1;
+            background: rgba(255, 255, 255, 0.07);
+            border: 1px solid rgba(255, 255, 255, 0.14);
+            border-radius: 6px;
+            padding: 5px 9px;
+            font-size: 12px;
+            color: #e0e0e0;
+            outline: none;
+            transition: border-color 0.2s;
+        }
+
+        .folder-input:focus {
+            border-color: rgba(255, 82, 82, 0.5);
+        }
+
+        .folder-hint {
+            font-size: 11px;
+            color: rgba(255, 255, 255, 0.3);
+            margin-top: 5px;
+            min-height: 16px;
+        }
     </style>
 </head>
 <body>
     <div class="header">
         <h2>⬇️ Redgifs Downloader</h2>
-        <div class="version">v1.4</div>
+        <div class="version">v1.5</div>
     </div>
     <div class="info">
         Click the download button on any<br>Redgifs video to save it in HD.
@@ -165,5 +301,30 @@
             <a class="liberapay" href="https://liberapay.com/freerebirth" target="_blank">🎁 Liberapay</a>
         </div>
     </div>
+    <div class="settings-section">
+        <span class="toggle-label">Auto-skip Feed Ads</span>
+        <label class="toggle-switch">
+            <input type="checkbox" id="auto-skip-toggle">
+            <span class="toggle-slider"></span>
+        </label>
+    </div>
+    <div class="folder-section">
+        <span class="folder-section-label">📁 Download Location</span>
+        <div class="radio-group">
+            <label class="radio-option">
+                <input type="radio" name="folder-mode" id="folder-mode-none" value="none">
+                Downloads folder
+            </label>
+            <label class="radio-option">
+                <input type="radio" name="folder-mode" id="folder-mode-sub" value="sub">
+                Subfolder
+            </label>
+        </div>
+        <div class="folder-input-row" id="folder-input-row">
+            <input type="text" class="folder-input" id="folder-name-input" placeholder="Redgifs" maxlength="64">
+        </div>
+        <div class="folder-hint" id="folder-hint"></div>
+    </div>
+    <script src="popup.js"></script>
 </body>
 </html>

--- a/firefox/popup.js
+++ b/firefox/popup.js
@@ -1,0 +1,85 @@
+document.addEventListener('DOMContentLoaded', () => {
+    // ── Ad-skip toggle ──────────────────────────────────────────────
+    const skipToggle = document.getElementById('auto-skip-toggle');
+
+    browser.storage.local.get('autoSkipAds').then((result) => {
+        skipToggle.checked = result.autoSkipAds || false;
+    });
+
+    skipToggle.addEventListener('change', (e) => {
+        browser.storage.local.set({ autoSkipAds: e.target.checked });
+    });
+
+    // ── Download Location ───────────────────────────────────────────
+    const radioNone    = document.getElementById('folder-mode-none');
+    const radioSub     = document.getElementById('folder-mode-sub');
+    const inputRow     = document.getElementById('folder-input-row');
+    const folderInput  = document.getElementById('folder-name-input');
+    const folderHint   = document.getElementById('folder-hint');
+
+    function updateHint(folderName) {
+        if (radioSub.checked && folderName) {
+            folderHint.textContent = 'Saves to: Downloads/' + folderName.trim().replace(/\/+$/, '') + '/';
+        } else if (radioNone.checked) {
+            folderHint.textContent = 'Saves directly to: Downloads/';
+        } else {
+            folderHint.textContent = '';
+        }
+    }
+
+    function applySubfolderMode(folderName) {
+        inputRow.classList.add('visible');
+        folderInput.value = folderName;
+        updateHint(folderName);
+    }
+
+    function applyNoFolderMode() {
+        inputRow.classList.remove('visible');
+        updateHint('');
+    }
+
+    // Load saved state
+    browser.storage.local.get('downloadFolder').then((result) => {
+        // null/undefined = first install → default to subfolder "Redgifs"
+        // "" = user explicitly chose no subfolder
+        if (result.downloadFolder === '') {
+            radioNone.checked = true;
+            applyNoFolderMode();
+        } else {
+            const name = (result.downloadFolder || 'Redgifs/').replace(/\/$/, '');
+            radioSub.checked = true;
+            applySubfolderMode(name);
+        }
+    });
+
+    // Radio: Downloads folder
+    radioNone.addEventListener('change', () => {
+        if (radioNone.checked) {
+            applyNoFolderMode();
+            browser.storage.local.set({ downloadFolder: '' });
+        }
+    });
+
+    // Radio: Subfolder
+    radioSub.addEventListener('change', () => {
+        if (radioSub.checked) {
+            const name = folderInput.value.trim() || 'Redgifs';
+            folderInput.value = name;
+            applySubfolderMode(name);
+            browser.storage.local.set({ downloadFolder: name + '/' });
+        }
+    });
+
+    // Debounced folder name input
+    let debounceTimer = null;
+    folderInput.addEventListener('input', () => {
+        updateHint(folderInput.value);
+        clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(() => {
+            const name = folderInput.value.trim();
+            if (name) {
+                browser.storage.local.set({ downloadFolder: name + '/' });
+            }
+        }, 600);
+    });
+});


### PR DESCRIPTION
## Summary

Closes the UX gap reported by a user who couldn't find where to change the download folder setting — it was only possible via the browser console.

## What's new

A **Download Location** section is now visible in the extension popup for both Chrome and Firefox.

| Option | Behaviour |
|---|---|
| Downloads folder | Saves directly to the browser's Downloads directory |
| Subfolder | Saves to a named subdirectory inside Downloads |

- The subfolder name is editable inline with a text input
- A live hint shows the resolved path (e.g. Downloads/Redgifs/)
- The choice persists across popup opens via storage.local
- Existing users (who never visited the popup) keep the default Redgifs/ subfolder behaviour

## Bug fix included

ackground.js was using || to resolve downloadFolder, which incorrectly fell back to DEFAULT_DOWNLOAD_FOLDER when the user explicitly chose no subfolder (empty string). Fixed to use ?? (nullish coalescing) instead.

## Files changed
- chrome/popup.html, irefox/popup.html — new UI section
- chrome/popup.js, irefox/popup.js — load/save logic
- chrome/background.js, irefox/background.js — ?? fix